### PR TITLE
remove ConfigParser requirement

### DIFF
--- a/library/ini_file2
+++ b/library/ini_file2
@@ -79,7 +79,6 @@ notes:
      options within the section can be updated. (This is a limitation of Python's I(ConfigParser).)
      Either use M(template) to create a base INI file with a C([default]) section, or use
      M(lineinfile) to add the missing line.
-requirements: [ ConfigParser ]
 author: "Jan-Piet Mens (@jpmens), Ales Nosek"
 '''
 
@@ -94,7 +93,6 @@ EXAMPLES = '''
             backup=yes
 '''
 
-import ConfigParser
 import sys
 
 # ==============================================================


### PR DESCRIPTION
This removes the ConfigParser import from the module, and also removes
the ConfigParser requirement noted in the documentation.  There
remains a reference to ConfigParser in the "notes" section, concerning
the behavior w/r/t a "default" section; I haven't tested the behavior
of the module in that case so I have left the reference in place.

Closes #1.
